### PR TITLE
Add permissions to make rpc endpoints of router apps private by default

### DIFF
--- a/backend/generator/common/server.py
+++ b/backend/generator/common/server.py
@@ -26,12 +26,7 @@ from schema import (
     SearchOptions,
     SearchResponse,
 )
-from syft_core.permissions import (
-    SyftPermission,
-    PermissionRule,
-    PermissionType,
-    PERM_FILE,
-)
+from syft_core.permissions import SyftPermission, PERM_FILE
 
 
 app_name = Path(__file__).resolve().parent.name
@@ -99,6 +94,7 @@ def setup_default_rpc_permissions(app: FastSyftBox):
     syft_perms.add_rule(
         path="**",
         user=str(app.syftbox_client.email),
+        permission=[],
     )
 
     # Set terminal=True to make this permission override child folder permissions

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import hashlib
 from fastapi import HTTPException
 from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -31,8 +32,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 # Initialize database
-db = Database(db_path=Path(__file__).parent.parent / "data" / "routers.db")
+def get_db_name() -> str:
+    db_name = f"{app.syftbox_config.email}-{app.syftbox_config.data_dir.resolve()}"
+    return hashlib.md5(db_name.encode()).hexdigest()
+
+
+db_name = get_db_name()
+db = Database(db_path=Path(__file__).parent.parent / "data" / f"{db_name}.db")
 db.create_db_and_tables()
 
 


### PR DESCRIPTION
This pull request introduces a set of changes to enhance security and flexibility in managing RPC endpoint visibility and database configurations. The key updates include implementing default permissions for RPC endpoints, allowing dynamic visibility toggling, and updating the database naming mechanism to ensure uniqueness.

### Enhancements to RPC Endpoint Permissions:
* Added a `setup_default_rpc_permissions` function in `backend/generator/common/server.py` to make RPC endpoints private by default, restricting access to the owner. This includes creating a permissions file (`PERM_FILE`) with terminal permissions that override child folder permissions. [[1]](diffhunk://#diff-c95456be4d4fa70a53caf8db643f45215e328bb41f9c67eeafee17fe1a39472fR61-R111) [[2]](diffhunk://#diff-c95456be4d4fa70a53caf8db643f45215e328bb41f9c67eeafee17fe1a39472fL67-R122)
* Introduced `_set_rpc_endpoints_visibility` in `backend/router/publish.py` to toggle RPC endpoint visibility between private (owner-only) and public (accessible to all users). This is used during `publish` and `unpublish` operations. [[1]](diffhunk://#diff-45dfe1fba8a5993e19334e584b66353b8cebfd72b3f1ada7f3aa7b60e3e2fd9cR60-R71) [[2]](diffhunk://#diff-45dfe1fba8a5993e19334e584b66353b8cebfd72b3f1ada7f3aa7b60e3e2fd9cR135-R137) [[3]](diffhunk://#diff-45dfe1fba8a5993e19334e584b66353b8cebfd72b3f1ada7f3aa7b60e3e2fd9cR171-R175)

### Database Configuration Updates:
* Updated the database initialization in `backend/main.py` to dynamically generate a unique database name based on the user's email and data directory. This ensures isolation and avoids conflicts in multi-user environments.

### Codebase Adjustments:
* Removed redundant `app_name` and `router` definitions from `backend/generator/common/server.py` to streamline the code. [[1]](diffhunk://#diff-c95456be4d4fa70a53caf8db643f45215e328bb41f9c67eeafee17fe1a39472fL89-L90) [[2]](diffhunk://#diff-c95456be4d4fa70a53caf8db643f45215e328bb41f9c67eeafee17fe1a39472fL102-L104)
* Added necessary imports for permissions handling and hashing in relevant files. [[1]](diffhunk://#diff-c95456be4d4fa70a53caf8db643f45215e328bb41f9c67eeafee17fe1a39472fR29-R32) [[2]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903R2) [[3]](diffhunk://#diff-45dfe1fba8a5993e19334e584b66353b8cebfd72b3f1ada7f3aa7b60e3e2fd9cR11)