### PR TITLE
Fix a small issue when /search rpc call is used without options / limits

### DIFF
--- a/backend/generator/common/schema.py
+++ b/backend/generator/common/schema.py
@@ -244,6 +244,16 @@ class EmbeddingResponse(SchemaBase):
     )
 
 
+class SearchDocumentsParams(SchemaBase):
+    """Parameters for document search request."""
+
+    # The search query
+    query: str = Field(..., description="The search query")
+
+    # Additional parameters for the search
+    options: Optional[SearchOptions] = None
+
+
 class SearchResponse(SchemaBase):
     """The result of the document search operation"""
 


### PR DESCRIPTION
This pull request refactors the document search functionality to improve code clarity and maintainability by introducing a new `SearchDocumentsParams` schema and updating the `search_documents` endpoint to use this schema. The key changes include the addition of the new schema, updates to the endpoint function signature, and adjustments to handle default parameters more cleanly.

### Refactoring of document search functionality:

* **New `SearchDocumentsParams` schema**:
  - Added a new schema class `SearchDocumentsParams` in `backend/generator/common/schema.py` to encapsulate the search query and options. This improves the structure and readability of the code by consolidating related parameters into a single object.

* **Update to `search_documents` endpoint**:
  - Changed the `search_documents` function signature in `backend/generator/common/server.py` to accept a `SearchDocumentsParams` object instead of individual parameters. This simplifies the function's interface and ensures consistency with the new schema.
  - Added logic to handle default values for `SearchOptions.limit` when it is not provided, ensuring a default limit of 3 is applied.

### Other updates:

* **Import updates**:
  - Added the import statement for `SearchDocumentsParams` in `backend/generator/common/server.py` to support the new schema.