### PR TITLE
Fix/add token generation rpc endpoint

### DIFF
--- a/backend/accounting/api.py
+++ b/backend/accounting/api.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional
+from urllib.parse import unquote
 
 from fastapi import APIRouter, HTTPException, Query
 from shared.exceptions import APIException
@@ -19,10 +20,12 @@ def build_accounting_api(accounting_manager: AccountingManager) -> APIRouter:
 
     router = APIRouter(prefix="/account")
 
-    @router.post("/token/create", response_model=TransactionToken)
-    async def create_txn_token(recipient_email: str) -> TransactionToken:
+    @router.post("/token/create", response_model=TransactionToken, tags=["syftbox"])
+    async def create_txn_token(recipient_email: str = Query(..., description="Email of the recipient")) -> TransactionToken:
         try:
-            return accounting_manager.create_txn_token(recipient_email)
+            # URL decode the email parameter in case it's encoded
+            decoded_email = unquote(recipient_email)
+            return accounting_manager.create_txn_token(decoded_email)
         except APIException as e:
             raise HTTPException(status_code=e.status_code, detail=e.message)
 

--- a/backend/accounting/manager.py
+++ b/backend/accounting/manager.py
@@ -138,6 +138,7 @@ class AccountingManager:
 
     def create_txn_token(self, recipient_email: str) -> TransactionToken:
         """Create a transaction token for a user email using given user authentication."""
+        logger.info(f"Creating transaction token for recipient_email: '{recipient_email}' (type: {type(recipient_email)}, repr: {repr(recipient_email)})")
         try:
             token = self.client.create_transaction_token(recipientEmail=recipient_email)
         except ServiceException as e:

--- a/backend/accounting/manager.py
+++ b/backend/accounting/manager.py
@@ -138,7 +138,6 @@ class AccountingManager:
 
     def create_txn_token(self, recipient_email: str) -> TransactionToken:
         """Create a transaction token for a user email using given user authentication."""
-        logger.info(f"Creating transaction token for recipient_email: '{recipient_email}' (type: {type(recipient_email)}, repr: {repr(recipient_email)})")
         try:
             token = self.client.create_transaction_token(recipientEmail=recipient_email)
         except ServiceException as e:


### PR DESCRIPTION
This pull request updates the `create_txn_token` API endpoint in `backend/accounting/api.py` to improve usability and robustness. The main changes include URL decoding the `recipient_email` parameter, adding OpenAPI documentation, and tagging the endpoint for better organization.

API improvements:

* The `recipient_email` parameter in `create_txn_token` is now URL-decoded to handle cases where the email address is sent in encoded form. (`[backend/accounting/api.pyL22-R28](diffhunk://#diff-d80764cbd5e0b54a3f40c0516a7c907a093f5d63fbd27ddb9f776a5bed6b0ea9L22-R28)`)
* The endpoint is tagged with `"syftbox"` and the parameter includes a description for improved OpenAPI documentation. (`[backend/accounting/api.pyL22-R28](diffhunk://#diff-d80764cbd5e0b54a3f40c0516a7c907a093f5d63fbd27ddb9f776a5bed6b0ea9L22-R28)`)

Dependency update:

* Imported `unquote` from `urllib.parse` to support decoding of the email parameter. (`[backend/accounting/api.pyR3](diffhunk://#diff-d80764cbd5e0b54a3f40c0516a7c907a093f5d63fbd27ddb9f776a5bed6b0ea9R3)`)