### PR TITLE
feat: add router_id to search_service and prepare router context setu…

### DIFF
--- a/backend/generator/templates/default/search_service.py
+++ b/backend/generator/templates/default/search_service.py
@@ -52,7 +52,11 @@ class LocalSearchService(SearchService):
         """Make a search request to the RAG service."""
         response = self.rag_client.post(
             "/api/search",
-            json={"query": query, "limit": limit},
+            json={
+                "query": query, 
+                "limit": limit,
+                "router_id": self.config.project_name
+            },
         )
         response.raise_for_status()
 

--- a/backend/generator/templates/default/spawn_services.py
+++ b/backend/generator/templates/default/spawn_services.py
@@ -305,6 +305,17 @@ class ServiceManager:
             else:
                 logger.info("✅ local-rag installed successfully")
 
+            # Set router context for local-rag
+            client = Client.load(self.config.syft_config.path)
+            app_folder = (
+                client.workspace.data_dir / "apps" / "com.github.openmined.local-rag"
+            )
+            
+            # Create router context file
+            # router_context_file = app_folder / ".env.router"
+            # router_context_file.write_text(f"CURRENT_ROUTER_ID={self.config.project.name}\n")
+            # logger.info(f"✅ Set router context: {self.config.project.name}")
+
             # Wait for local-rag to be ready and discover its URL
             logger.info("⏳ Waiting for local-rag to be ready...")
 


### PR DESCRIPTION
This pull request introduces improvements to how the router context is set and used in the local RAG (Retrieval-Augmented Generation) service. The main changes ensure that the router ID is included in search requests and lay the groundwork for setting router context during local RAG service startup.

**Integration of router context**

* The `__make_search_request` method in `search_service.py` now includes the `router_id` field in search requests, using the project's name from the configuration. This helps the RAG service route queries appropriately.

**Preparation for router context configuration**

* In `spawn_services.py`, code has been added to identify the app folder for local RAG and prepare for creating a router context file. Although the actual file creation is commented out, these changes set up the necessary context for future configuration.